### PR TITLE
fix: prevent crash while requesting directory

### DIFF
--- a/bin/http-live
+++ b/bin/http-live
@@ -95,7 +95,7 @@ http.createServer(function (req, res) {
 		abspath = process.cwd() + pathname;
 		console.log('REQUEST: ', req.method, pathname);
 
-		if (fs.existsSync(abspath)) {
+		if (fs.existsSync(abspath) && !fs.lstatSync(abspath).isDirectory() ) {
 			fs.readFile(abspath, function(err, data) {
 				var ext = pathname.slice(pathname.indexOf("."));
 				var mtype = getMimeType(ext);


### PR DESCRIPTION
### Summary
This pull request fixes the crash when you request a directory.
### Behavior
#### Before
Requesting `http://localhost:8080//` causes the crash of the server.
#### After
Requesting `http://localhost:8080//` won't cause the crash.